### PR TITLE
Update for WotLK 3.4.1

### DIFF
--- a/AngryAssignments_Wrath.toc
+++ b/AngryAssignments_Wrath.toc
@@ -1,0 +1,10 @@
+## Interface: 30401
+## Title: Angry Assignments
+## Author: Ermad
+## Version: @project-version@
+## SavedVariables: AngryAssign_Pages,AngryAssign_Categories,AngryAssign_State,AngryAssign_Config
+## OptionalDeps: Ace3, AceGUI-3.0-SharedMediaWidgets, LibCompress, LibWindow-1.1
+
+embeds.xml
+
+Core.lua

--- a/AngryTreeGroup.lua
+++ b/AngryTreeGroup.lua
@@ -568,7 +568,11 @@ local methods = {
 		if maxtreewidth > 100 and status.treewidth > maxtreewidth then
 			self:SetTreeWidth(maxtreewidth, status.treesizable)
 		end
-		treeframe:SetResizeBounds(100, 1, maxtreewidth, 1600)
+		if treeframe.SetResizeBounds then -- WoW 10.0
+			treeframe:SetResizeBounds(100, 1, maxtreewidth, 1600)
+		else
+			treeframe:SetMaxResize(maxtreewidth, 1600)
+		end
 	end,
 
 	["OnHeightSet"] = function(self, height)
@@ -647,7 +651,12 @@ local function Constructor()
 	treeframe:SetBackdropColor(0.1, 0.1, 0.1, 0.5)
 	treeframe:SetBackdropBorderColor(0.4, 0.4, 0.4)
 	treeframe:SetResizable(true)
-	treeframe:SetResizeBounds(100, 1, 400, 1600)
+	if treeframe.SetResizeBounds then -- WoW 10.0
+		treeframe:SetResizeBounds(100, 1, 400, 1600)
+	else
+		treeframe:SetMinResize(100, 1)
+		treeframe:SetMaxResize(400, 1600)
+	end
 	treeframe:SetScript("OnUpdate", FirstFrameUpdate)
 	treeframe:SetScript("OnSizeChanged", Tree_OnSizeChanged)
 	treeframe:SetScript("OnMouseWheel", Tree_OnMouseWheel)


### PR DESCRIPTION
This PR updates the addon to support Wrath of the Lich King 3.4.1, which is based on client 10.0.

I added some if-checks to make it backwards compatible with earlier versions. AceGUI has similar checks in place.