### PR TITLE
Register global AngryAssign

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2663,3 +2663,5 @@ function AngryAssign:AfterEnable()
 	self:UpdateDisplayedIfNewGroup()
 	self:SendVerQuery()
 end
+
+_G.AngryAssign = AngryAssign


### PR DESCRIPTION
I recently came across this [weak aura](https://wago.io/zITCQuozk) for ExRT that allows notes to be auto set when navigating through different Ulduar zones. Since my guild already uses Angry Assignments I attempted to adapt the weak aura for our purposes.

I was able to get things working without changes to Angry Assignments, but it relies on a somewhat janky method of editing the chat box text and faking an on enter pressed event. I ended up with this solution after hitting a wall with trying to use the `SlashCmdList` table as well as `ChatEdit_SendText` function which are both blocked by WeakAuras for different reasons.

Adding `AngryAssign` to the global environment allows other addons and weak auras to interact with more easily and without a hacky workaround.

I hope this is something you'll consider, happy to answer any questions I can.